### PR TITLE
builtin: add `sizeof` handling

### DIFF
--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -214,7 +214,7 @@ function find_escapes(ir::IRCode, nargs::Int)
                     # TODO implement more builtins, make them more accurate
                     if ft === Core.IntrinsicFunction # XXX we may break soundness here, e.g. `pointerref`
                         continue
-                    elseif ft === typeof(isa) || ft === typeof(typeof)
+                    elseif ft === typeof(isa) || ft === typeof(typeof) || ft === typeof(Core.sizeof)
                         continue
                     elseif ft === typeof(getfield) || ft === typeof(tuple)
                         info = state.ssavalues[pc]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,4 +178,16 @@ end
     end
 end
 
+
+@testset "builtins" begin
+
+    let # sizeof
+        src, escapes = analyze_escapes((Vector{Int}, )) do itr
+            sizeof(itr)
+        end
+        @test escapes.arguments[2] isa ReturnEscape
+    end
+
+end
+
 end # @testset "EscapeAnalysis" begin


### PR DESCRIPTION
Similar to `isa` and `typeof`, `sizeof` will not escape its arguments.