### PR TITLE
fix #8, fancy escape information printing

### DIFF
--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -398,9 +398,9 @@ end
 function print_with_info(io::IO, ir::IRCode, (; arguments, ssavalues)::EscapeState)
     function char_color(info::EscapeInformation)
         return info isa NoInformation ? ('◌', :plain) :
-               info isa NoEscape ? ('▲', :green) :
-               info isa ReturnEscape ? ('⮬', :yellow) :
-               info isa Escape ? ('➥', :red) :
+               info isa NoEscape ? ('↓', :green) :
+               info isa ReturnEscape ? ('↑', :yellow) :
+               info isa Escape ? ('→', :red) :
                throw("unhandled escape information: $c")
     end
 

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -376,8 +376,8 @@ function analyze_escapes(@nospecialize(f), @nospecialize(types=Tuple{});
     return EscapeAnalysisResult(interp.source, interp.info)
 end
 
-# utitlities
-# ==========
+# utilities
+# =========
 
 # in order to run a whole analysis from ground zero (e.g. for benchmarking, etc.)
 __clear_caches!() = (__clear_code_cache!(); __clear_escape_cache!())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,14 +180,12 @@ end
 
 
 @testset "builtins" begin
-
     let # sizeof
         src, escapes = analyze_escapes((Vector{Int}, )) do itr
             sizeof(itr)
         end
         @test escapes.arguments[2] isa ReturnEscape
     end
-
 end
 
 end # @testset "EscapeAnalysis" begin


### PR DESCRIPTION
Looks like this:
```julia
julia> @analyze_escapes sin(10)
typeof(sin)(_2::Int64 ↑, _3::Float64 ↓)
1 → 1 ─ %1 = Base.sitofp(Float64, _2)::Float64
2 ◌ └──      goto #3 if not false
3 ◌ 2 ─      nothing::Nothing
4 ↑ 3 ┄ %4 = invoke Base.Math.sin(%1::Float64)::Float64
5 ◌ └──      return %4

julia> @analyze_escapes sin(10)
typeof(sin)(_2::Int64 ⤒, _3::Float64 ⤓)
1 ⇥ 1 ─ %1 = Base.sitofp(Float64, _2)::Float64
2 ◌ └──      goto #3 if not false
3 ◌ 2 ─      nothing::Nothing
4 ⤒ 3 ┄ %4 = invoke Base.Math.sin(%1::Float64)::Float64
5 ◌ └──      return %4

julia> @analyze_escapes sin(10)
typeof(sin)(_2::Int64 ⮬, _3::Float64 ▲)
1 ➥ 1 ─ %1 = Base.sitofp(Float64, _2)::Float64
2 ◌ └──      goto #3 if not false
3 ◌ 2 ─      nothing::Nothing
4 ⮬ 3 ┄ %4 = invoke Base.Math.sin(%1::Float64)::Float64
5 ◌ └──      return %4
```