### PR TITLE
assert we're free from dynamic dispatches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+JETTest = "a79fb612-4a80-4749-a9bd-c2faab13da61"
 
 [targets]
-test = ["Test"]
+test = ["Test", "JETTest"]


### PR DESCRIPTION
Use [JETTest.jl](https://github.com/aviatesk/JETTest.jl) and assert we themselves are writing dispatch-free code.

E.g. it turns out the previous `Pair{Any,LatticeElement}` constructions
were type-unstable:
```julia
code quality: Dispatch Test Failed at /Users/aviatesk/julia/packages/EscapeAnalysis/test/runtests.jl:199
  Expression: #= /Users/aviatesk/julia/packages/EscapeAnalysis/test/runtests.jl:199 =# JETTest.@test_nodispatch function_filter = function_filter EscapeAnalysis.find_escapes(r.ir, 2)
  ═════ 19 possible errors found ═════
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:227 EscapeAnalysis.=>(%152, $(QuoteNode(Escape())))
  │ runtime dispatch detected: EscapeAnalysis.=>(%152::Any, $(QuoteNode(Escape()))::Escape)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:223 EscapeAnalysis.=>(%288, %200)
  │ runtime dispatch detected: EscapeAnalysis.=>(%288::Any, %200::EscapeInformation)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:223 EscapeAnalysis.push!(%11, %290)
  │ runtime dispatch detected: EscapeAnalysis.push!(%11::Vector{Pair{Any, EscapeInformation}}, %290::Pair)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:235 EscapeAnalysis.=>(%428, $(QuoteNode(Escape())))
  │ runtime dispatch detected: EscapeAnalysis.=>(%428::Any, $(QuoteNode(Escape()))::Escape)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:239 EscapeAnalysis.=>(%607, %608)
  │ runtime dispatch detected: EscapeAnalysis.=>(%607::Any, %608::EscapeInformation)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:239 EscapeAnalysis.push!(%11, %611)
  │ runtime dispatch detected: EscapeAnalysis.push!(%11::Vector{Pair{Any, EscapeInformation}}, %611::Pair)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:246 EscapeAnalysis.=>(%773, %685)
  │ runtime dispatch detected: EscapeAnalysis.=>(%773::Any, %685::EscapeInformation)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:246 EscapeAnalysis.push!(%11, %775)
  │ runtime dispatch detected: EscapeAnalysis.push!(%11::Vector{Pair{Any, EscapeInformation}}, %775::Pair)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:251 EscapeAnalysis.=>(%802, $(QuoteNode(Escape())))
  │ runtime dispatch detected: EscapeAnalysis.=>(%802::Any, $(QuoteNode(Escape()))::Escape)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:257 EscapeAnalysis.=>(%859, $(QuoteNode(Escape())))
  │ runtime dispatch detected: EscapeAnalysis.=>(%859::Any, $(QuoteNode(Escape()))::Escape)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:263 EscapeAnalysis.=>(%910, %908)
  │ runtime dispatch detected: EscapeAnalysis.=>(%910::Any, %908::EscapeInformation)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:263 EscapeAnalysis.push!(%11, %911)
  │ runtime dispatch detected: EscapeAnalysis.push!(%11::Vector{Pair{Any, EscapeInformation}}, %911::Pair)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:270 EscapeAnalysis.=>(%954, %917)
  │ runtime dispatch detected: EscapeAnalysis.=>(%954::Any, %917::EscapeInformation)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:270 EscapeAnalysis.push!(%11, %955)
  │ runtime dispatch detected: EscapeAnalysis.push!(%11::Vector{Pair{Any, EscapeInformation}}, %955::Pair)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:278 EscapeAnalysis.=>(%1010, %973)
  │ runtime dispatch detected: EscapeAnalysis.=>(%1010::Any, %973::EscapeInformation)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:278 EscapeAnalysis.push!(%11, %1011)
  │ runtime dispatch detected: EscapeAnalysis.push!(%11::Vector{Pair{Any, EscapeInformation}}, %1011::Pair)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:284 EscapeAnalysis.=>(%1034, %1032)
  │ runtime dispatch detected: EscapeAnalysis.=>(%1034::Any, %1032::EscapeInformation)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:284 EscapeAnalysis.push!(%11, %1035)
  │ runtime dispatch detected: EscapeAnalysis.push!(%11::Vector{Pair{Any, EscapeInformation}}, %1035::Pair)
  └───────────────────────────────────────────────────────────────────────────
  ┌ @ /Users/aviatesk/julia/packages/EscapeAnalysis/src/EscapeAnalysis.jl:288 EscapeAnalysis.=>(%1044, $(QuoteNode(ReturnEscape())))
  │ runtime dispatch detected: EscapeAnalysis.=>(%1044::Any, $(QuoteNode(ReturnEscape()))::ReturnEscape)
  └───────────────────────────────────────────────────────────────────────────
```