### PR TITLE
Only propagate escape information to non-bitstype arguments

### DIFF
--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -381,6 +381,7 @@ function escape_builtin!(::typeof(getfield), args::Vector{Any}, pc::Int, state::
     info === NoInformation() && (info = NoEscape())
     rt = widenconst(ir.stmts.type[pc])
     # Only propagate info when the field itself is non-bitstype
+    # TODO: we should remove this check when we implement the alias analysis
     if !isbitstype(rt)
         add_changes!(args[2:end], ir, info, changes)
     end

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -317,7 +317,7 @@ function find_escapes(ir::IRCode, nargs::Int)
     return state
 end
 
-function update_non_bitstype_changes!(args::Vector{Any}, ir::IRCode, info::EscapeInformation, changes::Changes)
+function update_non_bitstype_changes!(args::Vector{Any}, ir::IRCode, @nospecialize(info::EscapeInformation), changes::Changes)
     for arg in args[2:end]
         arg_type = widenconst(argextype(arg, ir, ir.sptypes, ir.argtypes))
         if !isbitstype(arg_type)

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -379,9 +379,9 @@ end
 function escape_builtin!(::typeof(getfield), args::Vector{Any}, pc::Int, state::EscapeState, ir::IRCode, changes::Changes)
     info = state.ssavalues[pc]
     info === NoInformation() && (info = NoEscape())
-    field_type = widenconst(ir.stmts.type[pc])
+    rt = widenconst(ir.stmts.type[pc])
     # Only propagate info when the field itself is non-bitstype
-    if !isbitstype(field_type)
+    if !isbitstype(rt)
         add_changes!(args[2:end], ir, info, changes)
     end
     return true

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -246,7 +246,10 @@ function find_escapes(ir::IRCode, nargs::Int)
                         info = state.ssavalues[pc]
                         info === NoInformation() && (info = NoEscape())
                         for arg in stmt.args[2:end]
-                            push!(changes, (arg, info))
+                            arg_typ = widenconst(argextype(arg, ir, sptypes, argtypes))
+                            if !(arg_typ <: Integer)
+                                push!(changes, (arg, info))
+                            end
                         end
                     # TODO: this can be removed once #3 is merged
                     elseif ft === typeof(Core.arrayset) && length(stmt.args) == 5
@@ -261,7 +264,10 @@ function find_escapes(ir::IRCode, nargs::Int)
                         push!(changes, (val, info))
                     else
                         for arg in stmt.args[2:end]
-                            push!(changes, (arg, Escape()))
+                            arg_typ = widenconst(argextype(arg, ir, sptypes, argtypes))
+                            if !(arg_typ <: Integer)
+                                push!(changes, (arg, Escape()))
+                            end
                         end
                     end
                 elseif head === :invoke

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,9 @@ end
     end
 end
 
+@testset "isbitstype" begin
+end
+
 @testset "control flows" begin
     let # branching
         src, escapes = analyze_escapes((Any,Bool,)) do a, c
@@ -270,6 +273,8 @@ end
             ft === typeof(Core.Compiler.widenconst) && return false # `widenconst` is very untyped, ignore
             ft === typeof(EscapeAnalysis.:(⊓)) && return false # `⊓` is very untyped, ignore
             ft === typeof(EscapeAnalysis.escape_builtin!) && return false # `escape_builtin!` is very untyped, ignore
+            ft === typeof(EscapeAnalysis.update_non_bitstype_changes!) && return false # `update_non_bitstype_changes` is very untyped, ignore
+            ft === typeof(Base.isbitstype) && return false # `isbitstype` is very untyped, ignore
             return true
         end
         test_nodispatch(only(methods(EscapeAnalysis.find_escapes)).sig; function_filter)


### PR DESCRIPTION
This PR make the following changes:
- `getfield` will not propagate escape information to its argument (field source) when the field it is getting is of integer type, even if itself is escaped. The reason is that getting an integer field should not affect the escape state of the source, in some sense it is pretty similar to `sizeof`.
- Furthermore, for `tuple` and also other calls (the `else` branch), we don't propagate the current statement's escape info to the arg if the arg itself is of integer type. The reason is that using a computed integer shouldn't create escape connections between statements. Integer typed statement should be an endpoint for an escape chain.

Notice this PR wouldn't solve #9 unless we handle foreigncall.

This method can theoretically be applied to any primitive type including integer, float, and char.
