### PR TITLE
refactor lattice queries

### DIFF
--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -512,6 +512,35 @@ function print_with_info(preprint, postprint, io::IO, ir::IRCode)
     return nothing
 end
 
+let
+    function mkqueryname(s)
+        names = String[]
+        buf = Char[]
+        for c in s
+            if isuppercase(c)
+                name = join(buf)
+                isempty(name) || push!(names, name)
+                empty!(buf)
+            end
+            push!(buf, lowercase(c))
+        end
+        name = join(buf)
+        isempty(name) || push!(names, name)
+
+        pushfirst!(names, "is")
+        return join(names, '_')
+    end
+
+    for t in subtypes(EscapeInformation)
+        s = nameof(t)
+        fn = Symbol(mkqueryname(string(s)))
+        @eval (@__MODULE__) begin
+            $fn(x::EscapeInformation) = isa(x, $s)
+            export $fn
+        end
+    end
+end
+
 export
     analyze_escapes,
     @analyze_escapes


### PR DESCRIPTION
We will redesign the lattice implementation in the near future
(to enable data flow propagation on aliased fields, etc.),
and so I think it's better if test cases don't rely on the internal
data structure of `EscapeInformation`.