### PR TITLE
RFC: make lattice concrete

### DIFF
--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -150,7 +150,7 @@ A lattice for escape information, which holds the following properties:
 These attributes can be combined to create a partial lattice:
 (note that this is inverted from the order used for the lattice in Core.Compiler)
 - `NoEscape`: the topmost element of this lattice
-- `Escape`: the inverse of NoEscape
+- `Escape`: the inverse of `NoEscape`
 - `AllEscape`: the bottom element of this lattice, meaning it will escape to everywhere
 
 An abstract state will be initialized with the top(most) elements, and an escape analysis

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -137,7 +137,7 @@ end
 # ========
 
 """
-    abstract type EscapeLattice end
+    struct EscapeLattice
 
 A lattice for escape information, which holds the following properties:
 - `Analyzed`: not formally part of the lattice, indicates this statement has not been analyzed at all

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -142,7 +142,7 @@ end
 A lattice for escape information, which holds the following properties:
 - `Analyzed`: not formally part of the lattice, indicates this statement has not been analyzed at all
 - `ReturnEscape`: indicates it will escape to the caller via return (possibly as a field)
-- `ArgEscape`: indicates it will escape to the caller through setfield on argument(s)
+- `ArgEscape`: indicates it will escape to the caller through `setfield!` on argument(s)
   -1 : no escape
    0 : unknown or multiple
    n : through argument N

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,7 +135,7 @@ end
         end
         i = findfirst(==(Base.RefValue{String}), src.stmts.type) # find allocation statement
         @assert !isnothing(i)
-        @test_broken is_return_escape(escapes.ssavalues[i])
+        @test is_return_escape(escapes.ssavalues[i])
     end
 
     @eval m @noinline f_returnescape(x) = broadcast(identity, x)
@@ -145,7 +145,7 @@ end
         end
         i = findfirst(==(Base.RefValue{String}), src.stmts.type) # find allocation statement
         @assert !isnothing(i)
-        @test_broken is_return_escape(escapes.ssavalues[i])
+        @test is_return_escape(escapes.ssavalues[i])
     end
 
     @eval m @noinline f_escape(x) = (global xx = x) # obvious escape
@@ -337,7 +337,6 @@ end
 
     function function_filter(@nospecialize(ft))
         ft === typeof(Core.Compiler.widenconst) && return false # `widenconst` is very untyped, ignore
-        ft === typeof(EscapeAnalysis.:(⊓)) && return false # `⊓` is very untyped, ignore
         ft === typeof(EscapeAnalysis.escape_builtin!) && return false # `escape_builtin!` is very untyped, ignore
         ft === typeof(isbitstype) && return false # `isbitstype` is very untyped, ignore
         return true


### PR DESCRIPTION
@aviatesk As we discussed, I was curious to see how this would work out. Seemed like this was a good test case for it, since the change was very simple with the current EscapeAnalysis design. As an example, I added some discussion of what ArgEscape would look like in this framework. I think ThrownEscape would also be simple to add to this (instead of making a dual throws/returns lattice, as we'd discussed somewhat on a recent call).

This will hopefully allow us to express a more complex lattice, and avoid unnecessary abstract dispatch in the analysis pass itself.