### PR TITLE
initialize non-call arguments as `NoInformation`

### DIFF
--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -208,7 +208,7 @@ struct EscapeState
 end
 function EscapeState(nslots::Int, nargs::Int, nstmts::Int)
     arguments = EscapeLattice[
-        i ≤ nargs ? ReturnEscape() : NoEscape() for i in 1:nslots]
+        i ≤ nargs ? ReturnEscape() : NoInformation() for i in 1:nslots]
     ssavalues = EscapeLattice[NoInformation() for _ in 1:nstmts]
     return EscapeState(arguments, ssavalues)
 end


### PR DESCRIPTION
Not sure why I initialized them as `NoEscape` before, but it's more
consistent with SSA values to initialize them as `NoInformation`.