### PR TITLE
make `ReturnEscape` flow-sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Couple of notes about this escape analysis:
 - the analysis is based on the [data-flow analysis](https://aviatesk.github.io/posts/data-flow-problem/) approach
 - it is a backward-analysis, i.e. escape information will flow from usage site to definition site
 - the algorithm works by updating the working set that contains program counters corresponding to SSA statements until every statement gets converged to a fixed point
-- it is flow-insensitive, i.e. doesn't distinguish escape information on the same "object" but at different locations
+- it only manages a single global state, some flow-sensitivity is encoded as `EscapeLattice` properties
 
 This escape analysis works on a lattice called `EscapeLattice`, which holds the following properties:
 - `x.Analyzed::Bool`: not formally part of the lattice, indicates this statement has not been analyzed at all
@@ -39,5 +39,5 @@ An abstract state will be initialized with the bottom(-like) elements:
 TODO:
 - [ ] implement more builtin function handlings, and make escape information more accurate
 - [ ] make analysis take into account alias information
-- [ ] make it flow-sensitive and implement `finalizer` elision optimization ([#17](https://github.com/aviatesk/EscapeAnalysis.jl/issues/17))
+- [ ] implement `finalizer` elision optimization ([#17](https://github.com/aviatesk/EscapeAnalysis.jl/issues/17))
 - [ ] circumvent too conservative escapes through potential `throw` calls by copying stack-to-heap on exception ([#15](https://github.com/aviatesk/EscapeAnalysis.jl/issues/15))

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ Couple of notes about this escape analysis:
 
 This escape analysis works on a lattice called `EscapeLattice`, which holds the following properties:
 - `x.Analyzed::Bool`: not formally part of the lattice, indicates this statement has not been analyzed at all
-- `x.ReturnEscape::Bool`: indicates it will escape to the caller via return (possibly as a field)
+- `x.ReturnEscape::BitSet`: keeps SSA numbers of return statements where it can be returned to the caller
+  * `isempty(x.ReturnEscape)` means it never escapes to the caller
+  * otherwise it indicates it will escape to the caller via return (possibly as a field),
+    where `0 ∈ x.ReturnEscape` has the special meaning that it's visible to the caller
+    simply because it's passed as call argument
 - `x.ThrownEscape::Bool`: indicates it may escape to somewhere through an exception (possibly as a field)
 - `x.GlobalEscape::Bool`: indicates it may escape to a global space an exception (possibly as a field)
 - `x.ArgEscape::Int` (not implemented yet): indicates it will escape to the caller through `setfield!` on argument(s)

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -346,9 +346,9 @@ function find_escapes(ir::IRCode, nargs::Int)
                     # TODO: we can apply a similar strategy like builtin calls to specialize some foreigncalls
                     foreigncall_nargs = length((stmt.args[3])::SimpleVector)
                     name = stmt.args[1]
-                    if normalize(name) === :jl_gc_add_finalizer_th
-                        continue # XXX assume this finalizer call is valid for finalizer elision
-                    end
+                    # if normalize(name) === :jl_gc_add_finalizer_th
+                    #     continue # XXX assume this finalizer call is valid for finalizer elision
+                    # end
                     push!(changes, (name, ThrownEscape()))
                     add_changes!(stmt.args[6:5+foreigncall_nargs], ir, ThrownEscape(), changes)
                 elseif head === :throw_undef_if_not # XXX when is this expression inserted ?
@@ -458,13 +458,13 @@ function propagate_changes!(state::EscapeState, changes::Changes)
     return anychanged
 end
 
-function normalize(@nospecialize(x))
-    if isa(x, QuoteNode)
-        return x.value
-    else
-        return x
-    end
-end
+# function normalize(@nospecialize(x))
+#     if isa(x, QuoteNode)
+#         return x.value
+#     else
+#         return x
+#     end
+# end
 
 function add_changes!(args::Vector{Any}, ir::IRCode, info::EscapeLattice, changes::Changes)
     for x in args

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -297,7 +297,8 @@ function find_escapes(ir::IRCode, nargs::Int)
     (; stmts, sptypes, argtypes) = ir
     nstmts = length(stmts)
 
-    state = EscapeState(length(ir.argtypes), nargs, nstmts) # flow-insensitive, only manage a single state
+    # only manage a single state, some flow-sensitivity is encoded as `EscapeLattice` properties
+    state = EscapeState(length(ir.argtypes), nargs, nstmts)
     changes = Changes() # stashes changes that happen at current statement
 
     while true


### PR DESCRIPTION
This PR will be a basis of [the `finalize` elision optimization](#17).

With this PR, `EscapeLattice` encodes flow-sensitivity in a way that
`EscapeLattice.ReturnEscape::BitSet` holds all program counters where
the target object escapes to the caller.

It also helps us distinguish the difference between the cases
- `EscapeLattice.ReturnEscape == BitSet(0)`: indicates "returns to the caller because it's visible from the caller"
- otherwise, it indicates "returns to the caller as return value"
and this will make `from_interprocedural` more accurate.

I also added some scaffold to implement the actual `finalizer` elision
optimization pass. As for the implementation, I'm thinking the following
approach:
- at each return site, the new optimization pass will lookup for mutable
  objects that are visible there
- for each mutable object, check the validity of the optimization using
  the `can_elide_finalizer` utility query, which checks following escape
  properties:
  * `!GlobalEscape`: the object shouldn't live somewhere
  * `0 ∉ x.ReturnEscape`: the object shouldn't return to the caller as argument
  * `pc ∉ x.ReturnEscape`: the object shouldn't return to the caller at the return site
  * note that we don't need to take `ThrownEscape` into consideration
    here since it would have never been thrown when the program
    execution reaches the `return` site.
- if it passes the `can_elide_finalizer` query, we will insert `finalize`
  call (maybe we also want to inline it ?)