### PR TITLE
propagate escape information imposed on exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ This analysis works on a lattice called `EscapeLattice`, which holds the followi
   * otherwise it indicates it will escape to the caller via return (possibly as a field),
     where `0 ∈ x.ReturnEscape` has the special meaning that it's visible to the caller
     simply because it's passed as call argument
-- `x.ThrownEscape::Bool`: indicates it may escape to somewhere through an exception (possibly as a field)
+- `x.ThrownEscape::$CatchRegions`: keeps regions where this object can be caught as an exception
+  * `isempty(x.ThrownEscape)` means it never escapes as an exception
+  * otherwise it indicates it may escape to somewhere through an exception (possibly as a field),
+    where `$UNHANDLED_REGION` has the following special meanings:
+    + `$UNHANDLED_REGION ∉ x.ThrownEscape`: means it can be handled within this frame, and thus won't escape to somewhere
+    + `$UNHANDLED_REGION ∈ x.ThrownEscape`: means it won't be handled within this frame, and thus may escape to somewhere through an exception (possibly as a field)
 - `x.GlobalEscape::Bool`: indicates it may escape to a global space an exception (possibly as a field)
 - `x.ArgEscape::Int` (not implemented yet): indicates it will escape to the caller through `setfield!` on argument(s)
   * `-1` : no escape


### PR DESCRIPTION
This PR extends `EscapeLattice` so that it propagates escape information
imposed on exception.

Rather than taking the easiest way, i.e. just propagate escape information
imposed on an exception object to _everywhere_, this PR tries to observe
the active exception handling region and limit the escape information
propagation to only those used in that region.

Firstly, `EscapeLattice.ThrownEscape` is extended to have type `Vector{UnitRange{Int}}`
and keep regions where this object can be caught as an exception, where
it has the following meaning:
* `isempty(x.ThrownEscape)` means it never escapes as an exception
* otherwise it indicates it may escape to somewhere through an exception (possibly as a field),
  where `$UNHANDLED_REGION` has the following special meanings:
  + `$UNHANDLED_REGION ∉ x.ThrownEscape`: means it can be handled within this frame, and thus won't escape to somewhere
  + `$UNHANDLED_REGION ∈ x.ThrownEscape`: means it won't be handled within this frame, and thus may escape to somewhere through an exception (possibly as a field)

Next, in the analysis body, we observe `%pc = Expr(:pop_exception, %n)`
expression and update active exception handling region as `active_region = n:pc`,
and use it for `ThrownEscape(active_region)` if something can be `throw`n.
Then we can propagate escape information imposed on `:the_exception` to
both arguments and SSA values whose `ThrownEscape` includes the active
exception handling region.
The active exception handling region is initialized as `[UNHANDLED_REGION]`, that
means it won't be handled in the current analysis frame.

Now we can limitedly propagate escape information imposed on exception
so that it's only propagated to those used in the active handling region:
```julia
let # sequence: escape information imposed on `err1` and `err2 should propagate separately
    result = analyze_escapes() do
        r1 = Ref("foo")            # GlobalEscape(`err1`) => `r1`, ReturnEscape(`err2`) ≠> `r2`
        r2 = Ref(:foo)             # ReturnEscape(`err2`) => `r2`, GlobalEscape(`err1`) ≠> `r2`
        local ret # prevent DCE
        try
            s1 = getfield(r1, :x)  # ThrownEscape => `r1`
            ret = sizeof(s1)
        catch err1
            global g = err1        # GlobalEscape => `err1`
        end
        try
            s2 = getfield(r2, :x)  # ThrownEscape => `r2`
            ret = sizeof(s2)
        catch err2
            ret = err2             # ReturnEscape(`ret`) => `err2`
        end
        return ret                 # ReturnEscape => `ret`
    end
    i1 = findfirst(==(Base.RefValue{String}), result.ir.stmts.type)
    @assert !isnothing(i1)
    @test has_thrown_escape(result.state.ssavalues[i1])
    @test !has_return_escape(result.state.ssavalues[i1])
    @test has_global_escape(result.state.ssavalues[i1])
    i2 = findfirst(==(Base.RefValue{Symbol}), result.ir.stmts.type)
    @assert !isnothing(i2)
    @test has_thrown_escape(result.state.ssavalues[i2])
    @test has_return_escape(result.state.ssavalues[i2])
    @test !has_global_escape(result.state.ssavalues[i2])
end

let # nested: ideally, escape information imposed on `err1` and `err2` should propagate separately
    result = analyze_escapes() do
        r = Ref("foo")           # ReturnEscape(`err`) ≠> `r`
        local ret # prevent DCE
        try
            s = getfield(r, :x)  # ThrownEscape => `r`
            try
                ret = sizeof(s)
            catch err
                return err       # ReturnEscape => `err`
            end
        catch
            ret = nothing
        end
        return ret
    end
    i = findfirst(==(Base.RefValue{String}), result.ir.stmts.type)
    @assert !isnothing(i)
    @test has_thrown_escape(result.state.ssavalues[i])
    @test !has_return_escape(result.state.ssavalues[i])
end
```

This approach assumes the linearity invariant that exception is always
handled between `%n = Expr(:enter)` and `%pc = Expr(:pop_exception, %n)`.
My main question is, is this invariant safe ?

---

In general, I'm not too confident in my understanding on exception
handling, so I'd really appreciate any feedback.