### PR TITLE
in-place state update and eliminate copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Couple of notes about this escape analysis:
 - the algorithm works by updating the working set that contains program counters corresponding to SSA statements until every statement gets converged to a fixed point
 - it is flow-insensitive, i.e. doesn't distinguish escape information on the same "object" but at different locations
 
-This escape analysis works on a lattice called `EscapeLattice,`, which holds the following properties:
+This escape analysis works on a lattice called `EscapeLattice`, which holds the following properties:
 - `x.Analyzed::Bool`: not formally part of the lattice, indicates this statement has not been analyzed at all
 - `x.ReturnEscape::Bool`: indicates it will escape to the caller via return (possibly as a field)
 - `x.ThrownEscape::Bool`: indicates it may escape to somewhere through an exception (possibly as a field)
@@ -32,6 +32,5 @@ An abstract state will be initialized with the bottom(-like) elements:
 TODO:
 - [ ] implement more builtin function handlings, and make escape information more accurate
 - [ ] make analysis take into account alias information
-- [ ] make it flow-sensitive and implement a `finalizer` elision optimization (#17)
-- [ ] port to the Julia base, and implement heap-to-stack optimization pass
-- [ ] circumvent too conservative escape through potential `throw` calls by copying stack-to-heap on exception (#15)
+- [ ] make it flow-sensitive and implement `finalizer` elision optimization ([#17](https://github.com/aviatesk/EscapeAnalysis.jl/issues/17))
+- [ ] circumvent too conservative escapes through potential `throw` calls by copying stack-to-heap on exception ([#15](https://github.com/aviatesk/EscapeAnalysis.jl/issues/15))


### PR DESCRIPTION
EscapeAnalysis's performance isn't so worse I believe, but the benchmark
below shows this PR slightly improves the performance. And the complexity
that comes with the in-place operations won't seem to be problematic in
my opinion:

> on `master`
```
~/julia/packages/EscapeAnalysis master
❯ julia -e 'using EscapeAnalysis, Plots; @time @analyze_escapes identity(nothing); @time @analyze_escapes plot(rand(10,3))'
  2.755029 seconds (3.38 M allocations: 176.415 MiB, 4.73% gc time)
 15.397738 seconds (70.17 M allocations: 4.042 GiB, 12.79% gc time)
```

> on `avi/alloc`
```
~/julia/packages/EscapeAnalysis avi/alloc
❯ julia -e 'using EscapeAnalysis, Plots; @time @analyze_escapes identity(nothing); @time @analyze_escapes plot(rand(10,3))'
  2.748207 seconds (3.31 M allocations: 172.596 MiB, 4.65% gc time)
 14.939631 seconds (69.50 M allocations: 3.659 GiB, 10.11% gc time)
```