### PR TITLE
fix strict lattice order `⋤`

### DIFF
--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -247,7 +247,7 @@ function ⊑(x::EscapeLattice, y::EscapeLattice)
     end
     return false
 end
-⋤(x::EscapeLattice, y::EscapeLattice) = !⊑(y, x)
+⋤(x::EscapeLattice, y::EscapeLattice) = ⊑(x, y) && !⊑(y, x)
 
 function ⊔(x::EscapeLattice, y::EscapeLattice)
     return EscapeLattice(


### PR DESCRIPTION
Pointed out at: 
https://github.com/aviatesk/EscapeAnalysis.jl/pull/43#discussion_r689634882