### PR TITLE
add support for array primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This analysis works on a lattice called `x::EscapeLattice`, which holds the foll
 - `x.ThrownEscape::Bool`: indicates `x` may escape to somewhere through an exception
 - `x.EscapeSites::BitSet`: records SSA statements where `x` can escape via any of
   `ReturnEscape` or `ThrownEscape`
-- `x.AliasEscapes::Union{Vector{BitSet},Bool}`: maintains all possible values that impose
-  escape information on fields of `x`
+- `x.AliasEscapes::Union{FieldEscapes,ArrayEscapes,Bool}`: maintains all possible values
+  that may escape objects that can be referenced from `x`:
 - `x.ArgEscape::Int` (not implemented yet): indicates it will escape to the caller through
   `setfield!` on argument(s)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This analysis works on a lattice called `x::EscapeLattice`, which holds the foll
 - `x.ThrownEscape::Bool`: indicates `x` may escape to somewhere through an exception
 - `x.EscapeSites::BitSet`: records SSA statements where `x` can escape via any of
   `ReturnEscape` or `ThrownEscape`
-- `x.FieldEscapes::Union{Vector{BitSet},Bool}`: maintains all possible values that impose
+- `x.AliasEscapes::Union{Vector{BitSet},Bool}`: maintains all possible values that impose
   escape information on fields of `x`
 - `x.ArgEscape::Int` (not implemented yet): indicates it will escape to the caller through
   `setfield!` on argument(s)
@@ -41,7 +41,7 @@ forward analysis otherwise. As a result, this scheme enables a very simple imple
 escape analysis, e.g. `PhiNode` for example can be handled relatively easily by propagating
 escape information imposed on it to its predecessors.
 
-It would be also worth noting that the `FieldEscapes` property enables a backward field
+It would be also worth noting that the `AliasEscapes` property enables a backward field
 analysis. It records _all possibilities that can escape fields of object_ at "usage" sites,
 and then escape information imposed on those escape possibilities are propagated to the
 actual field values later at "definition" site. More specifically, the analysis records a
@@ -54,7 +54,7 @@ v = getfield(obj, :val)
 return v
 ```
 In the example above, `ReturnEscape` imposed on `v` is _not_ directly propagated to `obj`.
-Rather the identity of `v` is recorded in `obj`'s `FieldEscapes[1]` and then `v`'s escape
+Rather the identity of `v` is recorded in `obj`'s `AliasEscapes[1]` and then `v`'s escape
 information is propagated to `val` when `obj = Expr(:new, Obj, val)` is analyzed.
 
 Finally, the analysis also needs to track which values can be aliased to each other. This is

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -181,7 +181,7 @@ end # register_init_hook!() do
 import Core: Argument, SSAValue
 import .CC: widenconst, singleton_type
 import .EA:
-    EscapeLattice, EscapeState, TOP_ESCAPE_SITES, BOT_FIELD_SETS, ⊑, ⊏, __clear_escape_cache!
+    EscapeLattice, EscapeState, TOP_ESCAPE_SITES, BOT_ALIAS_ESCAPES, ⊑, ⊏, __clear_escape_cache!
 
 # in order to run a whole analysis from ground zero (e.g. for benchmarking, etc.)
 __clear_caches!() = (__clear_code_cache!(); __clear_escape_cache!())
@@ -192,9 +192,9 @@ function get_name_color(x::EscapeLattice, symbol::Bool = false)
         name, color = (getname(EA.NotAnalyzed), "◌"), :plain
     elseif EA.has_no_escape(x)
         name, color = (getname(EA.NoEscape), "✓"), :green
-    elseif EA.NoEscape() ⊏ EA.ignore_fieldsets(x) ⊑ AllReturnEscape()
+    elseif EA.NoEscape() ⊏ EA.ignore_aliasescapes(x) ⊑ AllReturnEscape()
         name, color = (getname(EA.ReturnEscape), "↑"), :cyan
-    elseif EA.NoEscape() ⊏ EA.ignore_fieldsets(x) ⊑ AllThrownEscape()
+    elseif EA.NoEscape() ⊏ EA.ignore_aliasescapes(x) ⊑ AllThrownEscape()
         name, color = (getname(EA.ThrownEscape), "↓"), :yellow
     elseif EA.has_all_escape(x)
         name, color = (getname(EA.AllEscape), "X"), :red
@@ -202,14 +202,14 @@ function get_name_color(x::EscapeLattice, symbol::Bool = false)
         name, color = (nothing, "*"), :red
     end
     name = symbol ? last(name) : first(name)
-    if name !== nothing && EA.has_fieldsets(x)
+    if name !== nothing && EA.has_aliasescapes(x)
         name = string(name, "′")
     end
     return name, color
 end
 
-AllReturnEscape() = EscapeLattice(true, true, false, TOP_ESCAPE_SITES, BOT_FIELD_SETS)
-AllThrownEscape() = EscapeLattice(true, false, true, TOP_ESCAPE_SITES, BOT_FIELD_SETS)
+AllReturnEscape() = EscapeLattice(true, true, false, TOP_ESCAPE_SITES, BOT_ALIAS_ESCAPES)
+AllThrownEscape() = EscapeLattice(true, false, true, TOP_ESCAPE_SITES, BOT_ALIAS_ESCAPES)
 
 # pcs = sprint(show, collect(x.EscapeSites); context=:limit=>true)
 function Base.show(io::IO, x::EscapeLattice)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1030,6 +1030,169 @@ let result = @analyze_escapes compute!(MPoint(1+.5im, 2+.5im), MPoint(2+.25im, 4
     end
 end
 
+@testset "array primitives" begin
+    # arrayref
+    let result = analyze_escapes((Vector{String},Int)) do xs, i
+            s = Base.arrayref(true, xs, i)
+            return s
+        end
+        r = only(findall(isreturn, result.ir.stmts.inst))
+        @test has_return_escape(result.state[Argument(2)], r)   # xs
+        # @test !has_thrown_escape(result.state[Argument(2)])     # xs
+        @test !has_return_escape(result.state[Argument(3)], r)  # i
+    end
+    let result = analyze_escapes((Vector{String},Bool)) do xs, i
+            c = Base.arrayref(true, xs, i) # TypeError will happen here
+            return c
+        end
+        t = only(findall(iscall((result.ir, Base.arrayref)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs
+    end
+    let result = analyze_escapes((String,Int)) do xs, i
+            c = Base.arrayref(true, xs, i) # TypeError will happen here
+            return c
+        end
+        t = only(findall(iscall((result.ir, Base.arrayref)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs
+    end
+    let result = analyze_escapes((AbstractVector{String},Int)) do xs, i
+            c = Base.arrayref(true, xs, i) # TypeError may happen here
+            return c
+        end
+        t = only(findall(iscall((result.ir, Base.arrayref)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs
+    end
+    let result = analyze_escapes((Vector{String},Any)) do xs, i
+            c = Base.arrayref(true, xs, i) # TypeError may happen here
+            return c
+        end
+        t = only(findall(iscall((result.ir, Base.arrayref)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs
+    end
+
+    # arrayset
+    let result = analyze_escapes((Vector{String},String,Int,)) do xs, x, i
+            Base.arrayset(true, xs, x, i)
+            return xs
+        end
+        r = only(findall(isreturn, result.ir.stmts.inst))
+        @test has_return_escape(result.state[Argument(2)], r) # xs
+        @test has_return_escape(result.state[Argument(3)], r) # x
+    end
+    let result = analyze_escapes((String,String,String,)) do s, t, u
+            xs = Vector{String}(undef, 3)
+            Base.arrayset(true, xs, s, 1)
+            Base.arrayset(true, xs, t, 2)
+            Base.arrayset(true, xs, u, 3)
+            return xs
+        end
+        i = only(findall(isarrayalloc, result.ir.stmts.inst))
+        r = only(findall(isreturn, result.ir.stmts.inst))
+        @test has_return_escape(result.state[SSAValue(i)], r)
+        for i in 2:result.state.nargs
+            @test has_return_escape(result.state[Argument(i)], r)
+        end
+    end
+    let result = analyze_escapes((Vector{String},String,Bool,)) do xs, x, i
+            Base.arrayset(true, xs, x, i) # TypeError will happen here
+            return xs
+        end
+        t = only(findall(iscall((result.ir, Base.arrayset)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs
+        @test has_thrown_escape(result.state[Argument(3)], t) # x
+    end
+    let result = analyze_escapes((String,String,Int,)) do xs, x, i
+            Base.arrayset(true, xs, x, i) # TypeError will happen here
+            return xs
+        end
+        t = only(findall(iscall((result.ir, Base.arrayset)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs::String
+        @test has_thrown_escape(result.state[Argument(3)], t) # x::String
+    end
+    let result = analyze_escapes((AbstractVector{String},String,Int,)) do xs, x, i
+            Base.arrayset(true, xs, x, i) # TypeError may happen here
+            return xs
+        end
+        t = only(findall(iscall((result.ir, Base.arrayset)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs
+        @test has_thrown_escape(result.state[Argument(3)], t) # x
+    end
+    let result = analyze_escapes((Vector{String},AbstractString,Int,)) do xs, x, i
+            Base.arrayset(true, xs, x, i) # TypeError may happen here
+            return xs
+        end
+        t = only(findall(iscall((result.ir, Base.arrayset)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t) # xs
+        @test has_thrown_escape(result.state[Argument(3)], t) # x
+    end
+    let result = analyze_escapes((Vector{Any},AbstractString,Int,)) do xs, x, i
+            Base.arrayset(true, xs, x, i) # TypeError may happen here
+            return xs
+        end
+        t = only(findall(iscall((result.ir, Base.arrayset)), result.ir.stmts.inst))
+        @test !has_thrown_escape(result.state[Argument(2)], t) # xs
+        @test !has_thrown_escape(result.state[Argument(3)], t) # x
+    end
+
+    # arrayref and arrayset
+    let result = analyze_escapes() do
+            a = Vector{Any}[]
+            b = Any[]
+            a[1] = b
+            return a[1]
+        end
+        r = only(findall(isreturn, result.ir.stmts.inst))
+        ai = only(findall(result.ir.stmts.inst) do @nospecialize x
+            isarrayalloc(x) && x.args[2] === Vector{Vector{Any}}
+        end)
+        bi = only(findall(result.ir.stmts.inst) do @nospecialize x
+            isarrayalloc(x) && x.args[2] === Vector{Any}
+        end)
+        @test !has_return_escape(result.state[SSAValue(ai)], r)
+        @test has_return_escape(result.state[SSAValue(bi)], r)
+    end
+    let result = analyze_escapes() do
+            a = Vector{Any}[]
+            b = Any[]
+            a[1] = b
+            return a
+        end
+        r = only(findall(isreturn, result.ir.stmts.inst))
+        ai = only(findall(result.ir.stmts.inst) do @nospecialize x
+            isarrayalloc(x) && x.args[2] === Vector{Vector{Any}}
+        end)
+        bi = only(findall(result.ir.stmts.inst) do @nospecialize x
+            isarrayalloc(x) && x.args[2] === Vector{Any}
+        end)
+        @test has_return_escape(result.state[SSAValue(ai)], r)
+        @test has_return_escape(result.state[SSAValue(bi)], r)
+    end
+    let result = analyze_escapes((Vector{Any},String,Int,Int)) do xs, s, i, j
+            x = SafeRef(s)
+            xs[i] = x
+            xs[j] # potential error
+        end
+        i = only(findall(isnew, result.ir.stmts.inst))
+        t = only(findall(iscall((result.ir, Base.arrayref)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(3)], t) # s
+        @test has_thrown_escape(result.state[SSAValue(i)], t) # x
+    end
+end
+
+# demonstrate array primitive support with a realistic end to end example
+let result = analyze_escapes((Int,)) do n
+        xs = Int[]
+        for i in 1:n
+            push!(xs, i)
+        end
+        xs
+    end
+    i = only(findall(isarrayalloc, result.ir.stmts.inst))
+    r = only(findall(isreturn, result.ir.stmts.inst))
+    @test has_return_escape(result.state[SSAValue(i)], r)
+    @test_broken !has_thrown_escape(result.state[SSAValue(i)])
+end
+
 # demonstrate a simple type level analysis can sometimes improve the analysis accuracy
 # by compensating the lack of yet unimplemented analyses
 @testset "special-casing bitstype" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1177,6 +1177,26 @@ end
         @test has_thrown_escape(result.state[Argument(3)], t) # s
         @test has_thrown_escape(result.state[SSAValue(i)], t) # x
     end
+
+    # arraysize
+    let result = analyze_escapes((Vector{Any},)) do xs
+            Core.arraysize(xs, 1)
+        end
+        t = only(findall(iscall((result.ir, Core.arraysize)), result.ir.stmts.inst))
+        @test !has_thrown_escape(result.state[Argument(2)], t)
+    end
+    let result = analyze_escapes((Vector{Any},Int,)) do xs, dim
+            Core.arraysize(xs, dim)
+        end
+        t = only(findall(iscall((result.ir, Core.arraysize)), result.ir.stmts.inst))
+        @test !has_thrown_escape(result.state[Argument(2)], t)
+    end
+    let result = analyze_escapes((Any,)) do xs
+            Core.arraysize(xs, 1)
+        end
+        t = only(findall(iscall((result.ir, Core.arraysize)), result.ir.stmts.inst))
+        @test has_thrown_escape(result.state[Argument(2)], t)
+    end
 end
 
 # demonstrate array primitive support with a realistic end to end example

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1325,6 +1325,15 @@ end
         @test has_thrown_escape(result.state[Argument(2)], t)
         @test has_return_escape(result.state[Argument(2)], r)
     end
+
+    # isassigned
+    let result = analyze_escapes((Vector{Any},Int)) do xs, i
+            return isassigned(xs, i)
+        end
+        r = only(findall(isreturn, result.ir.stmts.inst))
+        @test !has_return_escape(result.state[Argument(2)], r)
+        @test !has_thrown_escape(result.state[Argument(2)])
+    end
 end
 
 # demonstrate array primitive support with a realistic end to end example

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -32,6 +32,14 @@ function isarrayalloc(@nospecialize x)
     end
     return false
 end
+function isarrayresize(@nospecialize x)
+    if Meta.isexpr(x, :foreigncall)
+        name = x.args[1]
+        nn = EscapeAnalysis.normalize(name)
+        return EscapeAnalysis.is_array_resize(nn) !== nothing
+    end
+    return false
+end
 import Core.Compiler: argextype, singleton_type
 const EMPTY_SPTYPES = Any[]
 iscall(y) = @nospecialize(x) -> iscall(y, x)


### PR DESCRIPTION
For now I'm trying to add a support so that we don't impose `ThrownEscape`/`AllEscape` on `xs` in the following example:
```julia
result = analyze_escapes((Int,)) do n
    xs = Int[]
    for i in 1:n
        push!(xs, i)
    end
    xs
end
```