### PR TITLE
propagate escapes via exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 
 This analysis works on a lattice called `x::EscapeLattice`, which holds the following properties:
 - `x.Analyzed::Bool`: not formally part of the lattice, indicates `x` has not been analyzed at all
-- `x.ReturnEscape::Bool`: indicates `x` may escape to the caller via return
-- `x.ThrownEscape::Bool`: indicates `x` may escape to somewhere through an exception
-- `x.EscapeSites::BitSet`: records SSA statements where `x` can escape via any of
-  `ReturnEscape` or `ThrownEscape`
+- `x.ReturnEscape::BitSet`: records SSA statements where `x` can escape to the caller via return
+- `x.ThrownEscape::BitSet`: records SSA statements where `x` can be thrown as exception
 - `x.AliasEscapes::Union{FieldEscapes,ArrayEscapes,Bool}`: maintains all possible values
   that may escape objects that can be referenced from `x`:
 - `x.ArgEscape::Int` (not implemented yet): indicates it will escape to the caller through
@@ -23,7 +21,7 @@ bottom to the top until every lattice element gets converged to a fixed point by
 a (conceptual) working set that contains program counters corresponding to remaining SSA
 statements to be analyzed. The analysis manages a single global state that tracks
 `EscapeLattice` of each argument and SSA statement, but also note that some flow-sensitivity
-is being encoded as program counters recorded in `EscapeLattice`'s `EscapeSites` property,
+is encoded as program counters recorded in `EscapeLattice`'s `ReturnEscape` property,
 which can be combined with domination analysis to reason about flow-sensitivity if necessary.
 
 One distinctive design of this analysis is that escape information is propagated in a

--- a/README.md
+++ b/README.md
@@ -1,19 +1,59 @@
 [![CI](https://github.com/aviatesk/EscapeAnalysis.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/aviatesk/EscapeAnalysis.jl/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/aviatesk/EscapeAnalysis.jl/branch/master/graph/badge.svg?token=ADEKPZRUJH)](https://codecov.io/gh/aviatesk/EscapeAnalysis.jl)
 
-`EscapeAnalysis` is a simple module that collects escape information from Julia's optimization IR (i.e. `IRCode`).
+`EscapeAnalysis` is a simple module that collects escape information in
+[Julia's SSA optimization IR](@id Julia-SSA-form-IR) a.k.a. `IRCode`.
 
-This analysis works on a lattice called `x::EscapeLattice`, which holds the following properties:
-- `x.Analyzed::Bool`: not formally part of the lattice, indicates `x` has not been analyzed at all
+## Analysis Usage
+
+### Usages within High-level Optimization Passes
+
+When using `EscapeAnalysis` in Julia's high-level optimization pipeline, we can run
+`EscapeAnalysis.analyze_escapes(ir::IRCode) -> estate::EscapeState`  to analyze
+escape information of each SSA-IR elements in `ir`.
+
+Note that it should be most effective if `EscapeAnalysis.analyze_escapes` runs after inlining,
+as `EscapeAnalysis`'s interprocedural escape information handling is limited at this moment.
+
+Since the computational cost of `EscapeAnalysis.analyze_escapes` is not that cheap,
+it is more ideal to run it once and succeeding optimizations incrementally update
+the escape information upon IR transformation.
+
+```@docs
+EscapeAnalysis.analyze_escapes
+EscapeAnalysis.EscapeState
+EscapeAnalysis.cache_escapes!
+```
+
+### Entries for Debugging/Testing
+
+For testing and debugging purposes, `EscapeAnalysis` exports convenience entries for the escape analysis.
+```@docs
+EscapeAnalysis.code_escapes
+EscapeAnalysis.@code_escapes
+```
+
+## Analysis Design
+
+### Lattice design
+
+`EscapeAnalysis` is implemented as a [data-flow analysis](https://en.wikipedia.org/wiki/Data-flow_analysis)
+that works on a lattice called `x::EscapeLattice`, which has the following properties:
+- `x.Analyzed::Bool`: not formally part of the lattice, only indicates `x` has not been analyzed or not
 - `x.ReturnEscape::BitSet`: records SSA statements where `x` can escape to the caller via return
 - `x.ThrownEscape::BitSet`: records SSA statements where `x` can be thrown as exception
-- `x.AliasEscapes::Union{FieldEscapes,ArrayEscapes,Bool}`: maintains all possible values
-  that may escape objects that can be referenced from `x`:
+  (used for the [exception-handling](@id exception-handling) described below)
+- `x.AliasEscapes`: maintains all possibilities that may escape objects that can be referenced from `x`
+  (used for the [field/alias analysis](@id field-alias-analysis) described below)
 - `x.ArgEscape::Int` (not implemented yet): indicates it will escape to the caller through
   `setfield!` on argument(s)
 
 These attributes can be combined to create a partial lattice that has a finite height, given
-that input program has a finite number of statements, which is assured by Julia's semantics.
+the invariant that an input program has a finite number of statements, which is assured by Julia's semantics.
+The clever part of this lattice design is that it enables relatively simple analysis implementation
+by allowing it to handle each lattice property separately[^latticedesign].
+
+### Backward Analysis
 
 Escape analysis implementation is based on the data-flow algorithm described in the paper[^MM02].
 The analysis works on the lattice of `EscapeLattice` and transitions lattice elements from the
@@ -22,75 +62,259 @@ a (conceptual) working set that contains program counters corresponding to remai
 statements to be analyzed. The analysis manages a single global state that tracks
 `EscapeLattice` of each argument and SSA statement, but also note that some flow-sensitivity
 is encoded as program counters recorded in `EscapeLattice`'s `ReturnEscape` property,
-which can be combined with domination analysis to reason about flow-sensitivity if necessary.
+which can be combined with domination analysis later to reason about flow-sensitivity if necessary.
 
-One distinctive design of this analysis is that escape information is propagated in a
-_backward_ way, i.e. data flows _from usages to definitions_.
-For example, in the code snippet below, EA first analyzes the statement `return obj` and
-imposes `ReturnEscape` on `obj`, and then it analyzes `obj = Expr(:new, Obj, val)` and
-propagates `ReturnEscape` imposed on `obj` to `val`:
+One distinctive design of this data-flow analysis is that it is fully _backward_,
+i.e. escape information flows _from usages to definitions_.
+For example, in the code snippet below, EA first analyzes the statement `return %1` and
+imposes `ReturnEscape` on `obj`, and then it analyzes `%new(Base.RefValue{String, _2}))`
+and propagates `ReturnEscape` imposed on `obj` to `s`:
 ```julia
-obj = Expr(:new, Obj, val) # lowered from `Obj(val)`
-return obj
+julia> code_escapes((String,)) do s
+           obj = Ref(s)
+           return obj
+       end
+#1(↑ _2::String) in Main at REPL[2]:2
+2 ↑  1 ─ %1 = %new(Base.RefValue{String}, _2)::Base.RefValue{String}                │╻╷╷ Ref
+3 ◌  └──      return %1                                                             │
 ```
+
 The key observation here is that this backward analysis allows escape information to flow
-naturally along the use-def chain rather than control-flow, which can be better handled by
-forward analysis otherwise. As a result, this scheme enables a very simple implementation of
-escape analysis, e.g. `PhiNode` for example can be handled relatively easily by propagating
-escape information imposed on it to its predecessors.
-
-It would be also worth noting that the `AliasEscapes` property enables a backward field
-analysis. It records _all possibilities that can escape fields of object_ at "usage" sites,
-and then escape information imposed on those escape possibilities are propagated to the
-actual field values later at "definition" site. More specifically, the analysis records a
-value that may impose escape information on field of object by analyzing `getfield` call,
-and then it propagates that escape information to the field when analyzing `Expr(:new)` or
-`setfield!` expressions.
+naturally along the use-def chain rather than control-flow[^backandforth].
+As a result, this scheme enables a simple implementation of escape analysis,
+e.g. `PhiNode` for example can be handled relatively simply by propagating
+escape information imposed on the `PhiNode` itself to its predecessor values:
 ```julia
-obj = Expr(:new, Obj, val)
-v = getfield(obj, :val)
-return v
+julia> code_escapes((Bool, String, String)) do cnd, s, t
+           if cnd
+               obj = Ref(s)
+           else
+               obj = Ref(t)
+           end
+           return obj
+       end
+  #3(↑ _2::Bool, ↑ _3::String, ↑ _4::String) in Main at REPL[3]:2
+2 ◌  1 ─      goto #3 if not _2                                                     │
+3 ↑  2 ─ %2 = %new(Base.RefValue{String}, _3)::Base.RefValue{String}                │╻╷╷ Ref
+  ◌  └──      goto #4                                                               │
+5 ↑  3 ─ %4 = %new(Base.RefValue{String}, _4)::Base.RefValue{String}                │╻╷╷ Ref
+7 ↑  4 ┄ %5 = φ (#2 => %2, #3 => %4)::Base.RefValue{String}                         │
+  ◌  └──      return %5                                                             │
 ```
-In the example above, `ReturnEscape` imposed on `v` is _not_ directly propagated to `obj`.
-Rather the identity of `v` is recorded in `obj`'s `AliasEscapes[1]` and then `v`'s escape
-information is propagated to `val` when `obj = Expr(:new, Obj, val)` is analyzed.
 
-Finally, the analysis also needs to track which values can be aliased to each other. This is
+### Field Analysis
+
+`EscapeAnalysis` implements a backward field analysis in order to reason about escapes
+imposed on object fields with certain accuracy,
+and `x::EscapeLattice`'s `x.AliasEscapes` property exists for this purpose.
+It records _all possibilities that can escape fields of `x`_ at "usage" sites, and then
+the recorded escapes are propagated to the actual field values later at "definition" site.
+More specifically, the analysis records a value that may impose escape information on
+a field of object by analyzing `getfield` call, and then it propagates that escape information
+to the field when analyzing `Expr(:new)` or `setfield!` expressions.
+```julia
+julia> mutable struct SafeRef{T}
+           x::T
+       end
+
+julia> Base.getindex(x::SafeRef) = x.x;
+
+julia> Base.setindex!(x::SafeRef, v) = x.x = v;
+
+julia> code_escapes((String,)) do s
+           obj = SafeRef("init")
+           obj[] = s
+           v = obj[]
+           return v
+       end
+#5(↑ _2::String) in Main at REPL[7]:2
+2 ✓′ 1 ─ %1 = %new(SafeRef{String}, "init")::SafeRef{String}                   │╻╷ SafeRef
+3 ◌  │        Base.setfield!(%1, :x, _2)::String                               │╻╷ setindex!
+4 ↑  │   %3 = Base.getfield(%1, :x)::String                                    │╻╷ getindex
+5 ◌  └──      return %3                                                        │
+```
+In the example above, `ReturnEscape` imposed on `v` is _not_ directly propagated to `obj`,
+and `ReturnEscape` isn't imposed on `%1 = %new(SafeRef{String}, "init")::SafeRef{String}`.
+Here the identity of `v` (`SSAValue(3)` in the above) is recorded in `obj`'s
+`AliasEscapes` property, and then when analyzing `Base.setfield!(%1, :x, _2)::String`,
+that escape information is propagated to `s` (`_2` or `Argument(2)` in the above)
+but not propagated to `obj` itself (`SSAValue(1)` in the above).
+
+However, in some cases such field analysis is impossible mostly because of the lack of precise
+type information. In such cases `AliasEscapes` property is raised to the topmost element
+within its lattice, and it makes succeeding field analysis conservative and propagate escapes
+imposed on fields of an unanalyzable object to the object itself.
+
+### Alias Analysis
+
+The escape analysis also needs to track which values can be aliased to each other. This is
 needed because in Julia IR, the same object is sometimes represented by different IR elements.
 Since the analysis maintains `EscapeLattice` per IR element, we need to make sure that those
 different IR elements that actually represent the same object to share the same escape information.
-Those program constructs that return the same object as their operand(s) like `PiNode` and
+Program constructs that return the same object as their operand(s) like `PiNode` and
 `typeassert` are obvious examples that require this escape information aliasing.
-But the escape information equalization between aliased values is needed for other cases as
-well, most notably, it is necessary for correctly reasoning about mutations on `PhiNode`.
+But the escape information equalization between aliased values is needed for other cases too,
+most notably, it is necessary for correctly reasoning about mutations on `PhiNode`.
 Let's consider the following example:
 ```julia
-if cond::Bool
-    ϕ2 = ϕ1 = Ref("foo")
-else
-    ϕ2 = ϕ1 = Ref("bar")
-end
-ϕ2[] = x::String
-y = ϕ1[]
-return y
+julia> code_escapes((Bool, String,)) do cond, x
+           if cond
+               ϕ2 = ϕ1 = SafeRef("foo")
+           else
+               ϕ2 = ϕ1 = SafeRef("bar")
+           end
+           ϕ2[] = x
+           y = ϕ1[]
+           return y
+       end
+#7(↑ _2::Bool, ↑ _3::String) in Main at REPL[8]:2
+2 ◌  1 ─      goto #3 if not _2                                                │
+3 ✓′ 2 ─ %2 = %new(SafeRef{String}, "foo")::SafeRef{String}                    │╻╷ SafeRef
+  ◌  └──      goto #4                                                          │
+5 ✓′ 3 ─ %4 = %new(SafeRef{String}, "bar")::SafeRef{String}                    │╻╷ SafeRef
+7 ✓′ 4 ┄ %5 = φ (#2 => %2, #3 => %4)::SafeRef{String}                          │
+  ✓′ │   %6 = φ (#2 => %2, #3 => %4)::SafeRef{String}                          │
+  ◌  │        Base.setfield!(%5, :x, _3)::String                               │╻  setindex!
+8 ↑  │   %8 = Base.getfield(%6, :x)::String                                    │╻╷ getindex
+9 ◌  └──      return %8                                                        │
 ```
-`ϕ1` and `ϕ2` are aliased and thus `ReturnEscape` imposed on `y = ϕ1[]` needs to be propagated to
-`ϕ2[] = x`. In order for the escape information to be propagated correctly, the escape states
-of _predecessors_ of `ϕ1` and `ϕ2` (i.e. those two `RefValue` objects) need to be shared ("equalized").
+`ϕ1 = SSAValue(5)` and `ϕ2 = SSAValue(6)` are aliased and thus `ReturnEscape` imposed on
+`%8 = Base.getfield(%6, :x)::String` (corresponding to `y = ϕ1[]`) needs to be propagated to
+`Base.setfield!(%5, :x, _3)::String` (corresponding to `ϕ2[] = x`).
+In order for such escape information to be propagated correctly, the analysis needs to
+recognize that the _predecessors_ of `ϕ1` and `ϕ2` are aliased and equalized their escape information.
 
-However, one interesting property of such alias information is that it is not known at "usage"
-site but can be derived at "definition" site (as aliasing is conceptually equivalent to assignment),
-and thus it doesn't naturally flow in a backward way. In order to efficiently propagate escape
+One interesting property of such aliasing information is that it is not known at "usage" site
+but can only be derived at "definition" site (as aliasing is conceptually equivalent to assignment),
+and thus it doesn't naturally fit in a backward analysis. In order to efficiently propagate escape
 information between related values, EscapeAnalysis.jl uses an approach inspired by the escape
-analysis algorithm explained in this old JVM paper[^JVM05]. That is, in addition to managing
+analysis algorithm explained in an old JVM paper[^JVM05]. That is, in addition to managing
 escape lattice elements, the analysis also maintains an "equi"-alias set, a disjoint set of
 aliased arguments and SSA statements. The alias set manages values that can be aliased to
 each other and allows new escape information imposed on any of such aliased values to be
 equalized between them.
 
+### Exception Handling
+
+It would be also noting how `EscapeAnalysis` handles possible escapes via exceptions.
+Naively it seems enough to propagate escape information imposed on `:the_exception` object to
+all values that may be thrown in a `try` block.
+But there are actually several other ways to access to the exception object in Julia,
+such as `Base.current_exceptions` and manual catch of `rethrow`n object.
+For example, escape analysis needs to account for potential escape of `r` in the example below:
+```julia
+julia> const Gx = Ref{Any}();
+
+julia> @noinline function rethrow_escape!()
+           try
+               rethrow()
+           catch err
+               Gx[] = err
+           end
+       end;
+
+julia> get′(x) = isassigned(x) ? x[] : throw(x);
+
+julia> code_escapes() do
+           r = Ref{String}()
+           local t
+           try
+               t = get′(r)
+           catch err
+               t = typeof(err)   # `err` (which `r` aliases to) doesn't escape here
+               rethrow_escape!() # but `r` escapes here
+           end
+           return t
+       end
+#9() in Main at REPL[12]:2
+2  X  1 ── %1  = %new(Base.RefValue{String})::Base.RefValue{String}            │╻╷ Ref
+4  ◌  2 ── %2  = $(Expr(:enter, #8))                                           │
+5  ◌  3 ── %3  = Base.isdefined(%1, :x)::Bool                                  │╻╷ get′
+   ◌  └───       goto #5 if not %3                                             ││
+   ↑  4 ── %5  = Base.getfield(%1, :x)::String                                 ││╻  getindex
+   ◌  └───       goto #6                                                       ││
+   ◌  5 ──       Main.throw(%1)::Union{}                                       ││
+   ◌  └───       unreachable                                                   ││
+   ◌  6 ──       $(Expr(:leave, 1))                                            │
+   ◌  7 ──       goto #10                                                      │
+   ◌  8 ──       $(Expr(:leave, 1))                                            │
+   ◌  9 ── %12 = $(Expr(:the_exception))::Any                                  │
+7  ↑  │    %13 = Main.typeof(%12)::DataType                                    │
+8  ◌  │          invoke Main.rethrow_escape!()::Any                            │
+   ◌  └───       $(Expr(:pop_exception, :(%2)))::Any                           │
+10 ↑  10 ┄ %16 = φ (#7 => %5, #9 => %13)::Union{DataType, String}              │
+   ◌  └───       return %16                                                    │
+```
+
+It requires a global analysis in order to reason about all possible escapes via existing
+exception interfaces correctly. As indicated by the above example, for now we always propagate
+the topmost escape information to all potentially thrown objects conservatively, since
+such an additional analysis might not be worthwhile to do given that exception handling and
+error path usually don't need to be very performance sensitive, and also optimizations of
+error paths might be very ineffective anyway since they are sometimes "unoptimized"
+intentionally for latency reasons.
+
+`x::EscapeLattice`'s `x.ThrownEscape` property records SSA statements where `x` can be thrown as exception.
+Using this information `EscapeAnalysis` can limited propagate possible escapes via exceptions
+to only those may be thrown in each `try` region:
+```julia
+julia> result = code_escapes((String,String)) do s1, s2
+           r1 = Ref(s1)
+           r2 = Ref(s2)
+           local ret
+           try
+               s1 = get′(r1)
+               ret = sizeof(s1)
+           catch err
+               global g = err # will definitely escape `r1`
+           end
+           s2 = get′(r2)      # still `r2` doesn't escape fully
+           return s2
+       end
+#11(X _2::String, ↑ _3::String) in Main at REPL[13]:2
+2  X  1 ── %1  = %new(Base.RefValue{String}, _2)::Base.RefValue{String}   │╻╷╷ Ref
+3  *′ └─── %2  = %new(Base.RefValue{String}, _3)::Base.RefValue{String}   │╻╷╷ Ref
+5  ◌  2 ── %3  = $(Expr(:enter, #8))                                      │
+   *′ └─── %4  = ϒ (%2)::Base.RefValue{String}                            │
+6  ◌  3 ── %5  = Base.isdefined(%1, :x)::Bool                             │╻╷  get′
+   ◌  └───       goto #5 if not %5                                        ││
+   X  4 ──       Base.getfield(%1, :x)::String                            ││╻   getindex
+   ◌  └───       goto #6                                                  ││
+   ◌  5 ──       Main.throw(%1)::Union{}                                  ││
+   ◌  └───       unreachable                                              ││
+7  ◌  6 ──       nothing::typeof(Core.sizeof)                             │╻   sizeof
+   ◌  │          nothing::Int64                                           ││
+   ◌  └───       $(Expr(:leave, 1))                                       │
+   ◌  7 ──       goto #10                                                 │
+   *′ 8 ── %15 = φᶜ (%4)::Base.RefValue{String}                           │
+   ◌  └───       $(Expr(:leave, 1))                                       │
+   X  9 ── %17 = $(Expr(:the_exception))::Any                             │
+9  ◌  │          (Main.g = %17)::Any                                      │
+   ◌  └───       $(Expr(:pop_exception, :(%3)))::Any                      │
+11 *′ 10 ┄ %20 = φ (#7 => %2, #9 => %15)::Base.RefValue{String}           │
+   ◌  │    %21 = Base.isdefined(%20, :x)::Bool                            ││╻   isassigned
+   ◌  └───       goto #12 if not %21                                      ││
+   ↑  11 ─ %23 = Base.getfield(%20, :x)::String                           │││╻   getproperty
+   ◌  └───       goto #13                                                 ││
+   ◌  12 ─       Main.throw(%20)::Union{}                                 ││
+   ◌  └───       unreachable                                              ││
+12 ◌  13 ─       return %23                                               │   
+```
+
+[^latticedesign]: Our type inference implementation takes the alternative approach,
+    where each lattice property is represented by a special lattice element type object.
+    It turns out that it makes started to complicate implementations of the lattice mainly
+    because it often requires conversion rules between each lattice element type object,
+    and we are actually working on [overhauling our type inference lattice implementation](https://github.com/JuliaLang/julia/pull/42596)
+    with `EscapeLattice`-like lattice design.
+
 [^MM02]: _A Graph-Free approach to Data-Flow Analysis_.
          Markas Mohnen, 2002, April.
          <https://api.semanticscholar.org/CorpusID:28519618>.
+
+[^backandforth]: In contrast, our type inference algorithm is implemented as a forward analysis,
+    because type information flows from "definition" to "usage" and it is more natural and
+    effective to propagate such information in a forward way.
 
 [^JVM05]: _Escape Analysis in the Context of Dynamic Compilation and Deoptimization_.
           Thomas Kotzmann and Hanspeter Mössenböck, 2005, June.

--- a/src/EscapeAnalysis.jl
+++ b/src/EscapeAnalysis.jl
@@ -457,7 +457,7 @@ if _TOP_MOD !== Core.Compiler
     argescapes_from_cache(cache::EscapeCache) = cache.cache
 else
     const GLOBAL_ESCAPE_CACHE = IdDict{MethodInstance,Vector{EscapeLatticeCache}}()
-    function cache_escapes!(linfo::MethodInstance, state::EscapeState, _::IRCode)
+    function cache_escapes!(linfo::MethodInstance, estate::EscapeState, _::IRCode)
         cache = to_interprocedural(estate)
         GLOBAL_ESCAPE_CACHE[linfo] = cache
         return cache

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -194,7 +194,7 @@ __clear_caches!() = (__clear_code_cache!(); EA.__clear_escape_cache!())
 
 function get_name_color(x::EscapeLattice, symbol::Bool = false)
     getname(x) = string(nameof(x))
-    if x == EA.NotAnalyzed()
+    if x === EA.⊥′
         name, color = (getname(EA.NotAnalyzed), "◌"), :plain
     elseif EA.has_no_escape(x)
         name, color = (getname(EA.NoEscape), "✓"), :green

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -194,7 +194,7 @@ __clear_caches!() = (__clear_code_cache!(); EA.__clear_escape_cache!())
 
 function get_name_color(x::EscapeLattice, symbol::Bool = false)
     getname(x) = string(nameof(x))
-    if x === EA.⊥′
+    if x === EA.⊥
         name, color = (getname(EA.NotAnalyzed), "◌"), :plain
     elseif EA.has_no_escape(x)
         name, color = (getname(EA.NoEscape), "✓"), :green

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,15 +15,111 @@ end
 
 using InteractiveUtils
 
+"""
+    @code_escapes [options...] f(args...)
+
+Evaluates the arguments to the function call, determines its types, and then calls
+[`code_escapes`](@ref) on the resulting expression.
+As with `@code_typed` and its family, any of `code_escapes` keyword arguments can be given
+as the optional arguments like `@code_escpase interp=myinterp myfunc(myargs...)`.
+"""
 macro code_escapes(ex0...)
     return InteractiveUtils.gen_call_with_extracted_types_and_kwargs(__module__, :code_escapes, ex0)
 end
 
-function code_escapes(@nospecialize(f), @nospecialize(types=Tuple{});
+"""
+    code_escapes(f, argtypes=Tuple{}; [world], [interp]) -> result::EscapeResult
+    code_escapes(tt::Type{<:Tuple}; [world], [interp]) -> result::EscapeResult
+
+Runs the escape analysis on optimized IR of a genefic function call with the given type signature.
+
+Note that the escape analysis runs after inlining, but before any other optimizations.
+
+[`EscapeState`](@ref) can be accessed by `result.state`.
+`result::EscapeResult` would be printed as like:
+```julia
+julia> mutable struct SafeRef{T}
+           x::T
+       end
+
+julia> Base.getindex(x::SafeRef) = x.x;
+
+julia> Base.isassigned(x::SafeRef) = true;
+
+julia> get′(x) = isassigned(x) ? x[] : throw(x);
+
+julia> result = code_escapes((String,String,String)) do s1, s2, s3
+           r1 = Ref(s1)
+           r2 = Ref(s2)
+           r3 = SafeRef(s3)
+           try
+               s1 = get′(r1)
+               ret = sizeof(s1)
+           catch err
+               global g = err # will definitely escape `r1`
+           end
+           s2 = get′(r2)      # still `r2` doesn't escape fully
+           s3 = get′(r3)      # still `r2` doesn't escape fully
+           return s2, s3
+       end
+#3(X _2::String, ↑ _3::String, ↑ _4::String) in Main at REPL[7]:2
+2  X  1 ── %1  = %new(Base.RefValue{String}, _2)::Base.RefValue{String}   │╻╷╷ Ref
+3  *′ │    %2  = %new(Base.RefValue{String}, _3)::Base.RefValue{String}   │╻╷╷ Ref
+4  ✓′ └─── %3  = %new(SafeRef{String}, _4)::SafeRef{String}               │╻╷  SafeRef
+5  ◌  2 ── %4  = \$(Expr(:enter, #8))                                      │
+   ✓′ │    %5  = ϒ (%3)::SafeRef{String}                                  │
+   *′ └─── %6  = ϒ (%2)::Base.RefValue{String}                            │
+6  ◌  3 ── %7  = Base.isdefined(%1, :x)::Bool                             │╻╷  get′
+   ◌  └───       goto #5 if not %7                                        ││
+   X  4 ──       Base.getfield(%1, :x)::String                            ││╻   getindex
+   ◌  └───       goto #6                                                  ││
+   ◌  5 ──       Main.throw(%1)::Union{}                                  ││
+   ◌  └───       unreachable                                              ││
+7  ◌  6 ──       nothing::typeof(Core.sizeof)                             │╻   sizeof
+   ◌  │          nothing::Int64                                           ││
+   ◌  └───       \$(Expr(:leave, 1))                                       │
+   ◌  7 ──       goto #10                                                 │
+   ✓′ 8 ── %17 = φᶜ (%5)::SafeRef{String}                                 │
+   *′ │    %18 = φᶜ (%6)::Base.RefValue{String}                           │
+   ◌  └───       \$(Expr(:leave, 1))                                       │
+   X  9 ── %20 = \$(Expr(:the_exception))::Any                             │
+9  ◌  │          (Main.g = %20)::Any                                      │
+   ◌  └───       \$(Expr(:pop_exception, :(%4)))::Any                      │
+11 ✓′ 10 ┄ %23 = φ (#7 => %3, #9 => %17)::SafeRef{String}                 │
+   *′ │    %24 = φ (#7 => %2, #9 => %18)::Base.RefValue{String}           │
+   ◌  │    %25 = Base.isdefined(%24, :x)::Bool                            ││╻   isassigned
+   ◌  └───       goto #12 if not %25                                      ││
+   ↑  11 ─ %27 = Base.getfield(%24, :x)::String                           │││╻   getproperty
+   ◌  └───       goto #13                                                 ││
+   ◌  12 ─       Main.throw(%24)::Union{}                                 ││
+   ◌  └───       unreachable                                              ││
+12 ↑  13 ─ %31 = Base.getfield(%23, :x)::String                           │╻╷╷ get′
+13 ↑  │    %32 = Core.tuple(%27, %31)::Tuple{String, String}              │
+   ◌  └───       return %32                                               │
+```
+
+, where the symbols in the side of each call argument and SSA statements represents the following meaning:
+- `◌`: this value is not analyzed because escape information of it won't be used anyway (when the object is `isbitstype` for example)
+- `✓`: this value never escapes (`has_no_escape(result.state[x])` holds)
+- `↑`: this value can escape to the caller via return (`has_return_escape(result.state[x])` holds)
+- `X`: this value can escape to somewhere the escape analysis can't reason about like escapes to a global memory (`has_all_escape(result.state[x])` holds)
+- `*`: this value's escape state is between the `ReturnEscape` and `AllEscape` in the `EscapeLattice`, e.g. it has unhandled `ThrownEscape`
+and additional `′` indicates that field analysis has been done successfully on that value.
+
+For testing, escape information of each call argument and SSA value can be inspected programmatically as like:
+```julia
+julia> result.state[Core.Argument(3)]
+ReturnEscape
+
+julia> result.state[Core.SSAValue(3)]
+NoEscape′
+```
+"""
+function code_escapes(@nospecialize(args...);
                       world = get_world_counter(),
                       interp = Core.Compiler.NativeInterpreter(world))
     interp = EscapeAnalyzer(interp)
-    results = code_typed(f, types; optimize=true, world, interp)
+    results = code_typed(args...; optimize=true, world, interp)
     isone(length(results)) || throw(ArgumentError("`code_escapes` only supports single analysis result"))
     return EscapeResult(interp.ir, interp.state, interp.linfo)
 end
@@ -258,7 +354,7 @@ function print_with_info(io::IO,
             arg = state[Argument(i)]
             i == 1 && continue
             c, color = get_name_color(arg, true)
-            printstyled(io, '_', i, "::", ir.argtypes[i], ' ', c; color)
+            printstyled(io, c, ' ', '_', i, "::", ir.argtypes[i]; color)
             i ≠ state.nargs && print(io, ", ")
         end
         print(io, ')')


### PR DESCRIPTION
This PR revives and replaces #39.
`EscapeLattice.ThrownEscape` is tracking where the object can be thrown,
but the analysis didn't impose potential escapes via exceptions using
that information. When using the analysis result, we previously needed
to be very conservative about `ThrownEscape` since it essentially needed
to be handled same as `ReturnEscape`. Still we can often ignore
`ThrownEscape` when implementing certain optimizations like `mutating_arrayfreeze`
optimization if the analysis accounts for potential escapes via exception.

This commit does propagate escape information imposed on exception object
to all objects that can potentially be thrown in current `try` region.
After this PR, the throwness of an object will be categorized as either of:
1. potential throw will be handled by a local `catch` handler:
   `analyze_escapes` will propagated possible escapes via exception to
   the object in question
2. potential throw won't be handled within a local frame: this indicates
   the object can be thrown and escaped to somewhere in caller frames
   (this case often can be ignored for implementing some optimizations)

The new escape routine `escape_exception!` propagates possible escapes via
exceptions. Naively it seems enough to propagate escape information
imposed on `:the_exception` object, but actually there are several other
ways to access to the exception object such as `Base.current_exceptions`
and manual catch of `rethrow`n object. For example, the escape analysis
needs to account for potential escape of the allocated object via
`rethrow_escape!()` call in the example below:
```julia
const Gx = Ref{Any}()
@noinline function rethrow_escape!()
    try
        rethrow()
    catch err
        Gx[] = err
    end
end
unsafeget(x) = isassigned(x) ? x[] : throw(x)

code_escapes() do
    r = Ref{String}()
    try
        t = unsafeget(r)
    catch err
        t = typeof(err)  # `err` (which `r` may alias to) doesn't escape here
        rethrow_escape!() # `r` can escape here
    end
    return t
end
```

As indicated by the above example, it requires a global analysis in
addition to a base escape analysis to reason about all possible escapes
via existing exception interfaces correctly. For now we conservatively
always propagate `AllEscape` to all potentially thrown objects, since
such an additional analysis might not be worthwhile to do given that
exception handling and error path usually don't need to be very
performance sensitive, and optimizations of error paths might be very
ineffective anyway since they are sometimes "unoptimized" intentionally
for latency reasons.

Specifically, `analyze_escapes` now first invokes `compute_tryregions`
that does a linear scan to find regions where potential `throw`s can be
caught (they are simply statements between `:enter` and `:leave` expressions).
`escape_exception!` is invoked after each statement iteration and will
propagate `AllEscape` to all SSA values and arguments whose `ThrownEscape`
intersects with any of `tryregions`.
In order to keep the analysis accuracy, now `ReturnEscape` and `ThrownEscape`
doesn't share the same program counter set (i.e. `EscapeSites`), and they
have each own `BitSet` program counter set.

Now possible escapes via exceptions are propagated limitedly to those may
be thrown in each `try` region:
```julia
let # sequential: escape information imposed on `err1` and `err2 should propagate separately
    result = analyze_escapes() do
        r1 = Ref{String}()
        r2 = Ref{String}()
        local ret
        try
            s1 = unsafeget(r1)
            ret = sizeof(s1)
        catch err
            global g = err # will escape `r1`
        end
        s2 = unsafeget(r2) # `r2` doesn't escape fully
        return s2, r2
    end
    is = findall(isnew, result.ir.stmts.inst)
    @test length(is) == 2
    i1, i2 = is
    r = only(findall(isreturn, result.ir.stmts.inst))
    @test has_all_escape(result.state[SSAValue(i1)])
    @test !has_all_escape(result.state[SSAValue(i2)])
    @test has_return_escape(result.state[SSAValue(i2)], r)
end
```