### PR TITLE
run `IPO EA` only when any of arguments is mutable

### DIFF
--- a/src/EAUtils.jl
+++ b/src/EAUtils.jl
@@ -74,7 +74,7 @@ import .CC:
     InferenceResult, OptimizationState, IRCode, copy as cccopy,
     @timeit, convert_to_ircode, slot2reg, compact!, ssa_inlining_pass!, sroa_pass!,
     adce_pass!, type_lift_pass!, JLOptions, verify_ir, verify_linetable
-import .EA: analyze_escapes, ArgEscapeInfo, EscapeInfo, EscapeState
+import .EA: analyze_escapes, ArgEscapeInfo, EscapeInfo, EscapeState, is_ipo_profitable
 
 # when working outside of Core.Compiler,
 # cache entire escape state for later inspection and debugging
@@ -207,13 +207,17 @@ function run_passes_with_ea(interp::EscapeAnalyzer, ci::CodeInfo, sv::Optimizati
     @timeit "compact 1" ir = compact!(ir)
     nargs = let def = sv.linfo.def; isa(def, Method) ? Int(def.nargs) : 0; end
     local state
-    try
-        @timeit "[IPO EA]" state = analyze_escapes(ir, nargs, false, getargescapes(interp))
-        cache_escapes!(interp, caller, state, cccopy(ir))
-    catch err
-        @error "error happened within [IPO EA], insepct `Main.ir` and `Main.nargs`"
-        @eval Main (ir = $ir; nargs = $nargs)
-        rethrow(err)
+    if is_ipo_profitable(ir, nargs) || caller.linfo.specTypes === interp.entry_tt
+        try
+            @timeit "[IPO EA]" begin
+                state = analyze_escapes(ir, nargs, false, getargescapes(interp))
+                cache_escapes!(interp, caller, state, cccopy(ir))
+            end
+        catch err
+            @error "error happened within [IPO EA], insepct `Main.ir` and `Main.nargs`"
+            @eval Main (ir = $ir; nargs = $nargs)
+            rethrow(err)
+        end
     end
     if caller.linfo.specTypes === interp.entry_tt && !interp.optimize
         # return back the result


### PR DESCRIPTION
This heuristic might be a bit too strict, but our test suite runs
successfully with it.
It seems to cut off much allocations:

> master
```
❯ julia -e 'using EscapeAnalysis; code_escapes(sin, (Int,)); @time code_escapes(Base.init_stdio, (Ptr{Cvoid},)); @time code_escapes(println, (QuoteNode,))'
  4.670233 seconds (27.81 M allocations: 1.497 GiB, 23.73% gc time, 95.42% compilation time)
  0.513737 seconds (2.86 M allocations: 193.693 MiB, 20.47% gc time, 99.98% compilation time)
```

> this PR
```
❯ julia -e 'using EscapeAnalysis; code_escapes(sin, (Int,)); @time code_escapes(Base.init_stdio, (Ptr{Cvoid},)); @time code_escapes(println, (QuoteNode,))'
  4.069632 seconds (26.14 M allocations: 1.385 GiB, 18.84% gc time, 94.76% compilation time)
  0.462201 seconds (2.72 M allocations: 182.187 MiB, 17.52% gc time, 99.99% compilation time)
```